### PR TITLE
Minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ We train our model in two stages:
 
 ```bash
 python train.py --model_name im2ingr --batch_size 150 --finetune_after 0 --ingrs_only \
---es_metric iou_sample --perminv_ingrs --loss_weight 0 1000.0 1.0 1.0 \
+--es_metric iou_sample --loss_weight 0 1000.0 1.0 1.0 \
 --learning_rate 1e-4 --scale_learning_rate_cnn 1.0 \
 --save_dir ../checkpoints --recipe1m_dir path_to_dataset
 ```
@@ -111,7 +111,7 @@ $ tensorboard --logdir='../tb_logs' --port=6006
 ### Evaluation
 
 - Save generated recipes to disk with
-```python sample.py --model_name model --greedy --eval_split test```.
+```python sample.py --model_name model --save_dir ../checkpoints --recipe1m_dir path_to_dataset --greedy --eval_split test```.
 - This script will return ingredient metrics (F1 and IoU)
 
 ### License

--- a/src/model.py
+++ b/src/model.py
@@ -211,7 +211,7 @@ class InverseCookingModel(nn.Module):
             ingr_ids[sample_mask == 0] = self.pad_value
 
             outputs['ingr_ids'] = ingr_ids
-            outputs['ingr_probs'] = ingr_probs
+            outputs['ingr_probs'] = ingr_probs.data
 
             mask = sample_mask
             input_mask = mask.float().unsqueeze(1)
@@ -230,7 +230,7 @@ class InverseCookingModel(nn.Module):
         ids, probs = self.recipe_decoder.sample(input_feats, input_mask, greedy, temperature, beam, img_features, 0,
                                                 last_token_value=1)
 
-        outputs['recipe_probs'] = probs
+        outputs['recipe_probs'] = probs.data
         outputs['recipe_ids'] = ids
 
         return outputs

--- a/src/train.py
+++ b/src/train.py
@@ -144,7 +144,7 @@ def main(args):
 
     # add model parameters
     if args.ingrs_only:
-        params = list(model.ingredient_decoder.parameters()) + list(model.ingredient_encoder.parameters())
+        params = list(model.ingredient_decoder.parameters())
     elif args.recipe_only:
         params = list(model.recipe_decoder.parameters()) + list(model.ingredient_encoder.parameters())
     else:


### PR DESCRIPTION
- Removed deprecated perminv_ingrs argument from README & improved instructions for sampling.
- Removed variables storing attention weights in the Transformer.
- Enable backward pass through ingredient decoder output.
- Optimizer does not have access to ingredient encoder weights when training for ingredient prediction.